### PR TITLE
Re-add the richer error reporting from my branch, attempt to unify eventing

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms
 	{
 		internal const string PropertyNotFoundErrorMessage = "'{0}' property not found on '{1}', target property: '{2}.{3}'";
 		internal const string ConvertErrorMessage = "{0} can not be converted to type '{1}'";
+		internal const string IndexParsingFailedErrorMessage = "{0} could not be parsed as an index for a {1}";
 
 		readonly List<BindingExpressionPart> _parts = new List<BindingExpressionPart>();
 
@@ -141,8 +142,8 @@ namespace Xamarin.Forms
 					{
 						var composedPropertyNotFoundMessage = string.Format(PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
 
-						DebugSettings.OnBindingFailed(sourceObject, composedPropertyNotFoundMessage);
-						
+						DebugSettings.OnPropertyNotFound(sourceObject, part.Content, current.ToString(), target.GetType(), property.PropertyName);
+
 						Log.Warning("Binding", composedPropertyNotFoundMessage);
 						break;
 					}
@@ -174,7 +175,7 @@ namespace Xamarin.Forms
 				{
 					var composedConvertErrorMessage = string.Format(ConvertErrorMessage, value, property.ReturnType);
 
-					DebugSettings.OnBindingFailed(sourceObject, composedConvertErrorMessage);
+					DebugSettings.OnConverterFailed(sourceObject, value, property.ReturnType);
 
 					Log.Warning("Binding", composedConvertErrorMessage);
 					return;
@@ -190,7 +191,7 @@ namespace Xamarin.Forms
 				{
 					var composedConvertErrorMessage = string.Format(ConvertErrorMessage, value, part.SetterType);
 
-					DebugSettings.OnBindingFailed(sourceObject, composedConvertErrorMessage);
+					DebugSettings.OnConverterFailed(sourceObject, value, part.SetterType);
 
 					Log.Warning("Binding", composedConvertErrorMessage);
 					return;
@@ -288,7 +289,11 @@ namespace Xamarin.Forms
 				{
 					int index;
 					if (!int.TryParse(part.Content, out index))
-						Log.Warning("Binding", "{0} could not be parsed as an index for a {1}", part.Content, sourceType);
+					{
+						var composedErrorMessage = string.Format(IndexParsingFailedErrorMessage, part.Content, sourceType);
+						DebugSettings.OnIndexParsingFailed(part.Content, sourceType);
+						Log.Warning("Binding", composedErrorMessage);
+					}
 					else
 						part.Arguments = new object[] { index };
 

--- a/Xamarin.Forms.Core/BindingFailedEventArgs.cs
+++ b/Xamarin.Forms.Core/BindingFailedEventArgs.cs
@@ -4,11 +4,48 @@ namespace Xamarin.Forms.Core
 {
 	public class BindingFailedEventArgs : EventArgs
 	{
-		public BindingFailedEventArgs(string message)
+		public BindingPropertyNotFound PropertyNotFound { get; set; }
+		public BindingConverterFailed ConverterFailed { get; set; }
+		public BindingIndexParsingFailed IndexParsingFailed { get; set; }
+	}	
+
+	public class BindingPropertyNotFound
+	{
+		public BindingPropertyNotFound(string bindingName, string bindingContext, Type targetType, string propertyName)
 		{
-			Message = message;
+			BindingName = bindingName;
+			BindingContext = bindingContext;
+			TargetType = targetType;
+			PropertyName = propertyName;
 		}
 
-		public string Message { get; set; }
+		public string BindingName { get; }
+		public string BindingContext { get; }
+		public Type TargetType { get; }
+		public string PropertyName { get; }
+	}
+
+	public class BindingConverterFailed
+	{
+		public BindingConverterFailed(object conversionTarget, Type targetType)
+		{
+			ConversionTarget = conversionTarget;
+			TargetType = targetType;
+		}
+
+		public object ConversionTarget { get; set; }
+		public Type TargetType { get; set; }
+	}
+
+	public class BindingIndexParsingFailed
+	{
+		public BindingIndexParsingFailed(string attemptedIndexString, Type sourceType)
+		{
+			AttemptedIndexString = attemptedIndexString;
+			SourceType = sourceType;
+		}
+
+		public string AttemptedIndexString { get; set; }
+		public Type SourceType { get; set; }
 	}
 }

--- a/Xamarin.Forms.Core/DebugSettings.cs
+++ b/Xamarin.Forms.Core/DebugSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace Xamarin.Forms.Core
 {
@@ -10,12 +12,61 @@ namespace Xamarin.Forms.Core
 
 		public static event BindingFailedEventHandler BindingFailed;
 
-		internal static void OnBindingFailed(Object sourceObject, string message)
+		internal static void OnPropertyNotFound(object sourceObject, string bindingName, string bindingContext, Type targetType, string propertyName)
 		{
 			if (!IsBindingTracingEnabled)
 				return;
 
-			BindingFailed?.Invoke(sourceObject, new BindingFailedEventArgs(message));
+			if (BindingFailed == null)
+			{
+				var composedPropertyNotFoundMessage = string.Format(BindingExpression.PropertyNotFoundErrorMessage, bindingName, bindingContext, targetType, propertyName);
+				Debug.WriteLine(composedPropertyNotFoundMessage);
+			}
+			else
+			{
+				BindingFailed.Invoke(sourceObject, new BindingFailedEventArgs
+				{
+					PropertyNotFound = new BindingPropertyNotFound(bindingName, bindingContext, targetType, propertyName)
+				});
+			}
+		}
+
+		internal static void OnConverterFailed(object sourceObject, object value, Type targetType)
+		{
+			if (!IsBindingTracingEnabled)
+				return;
+
+			if (BindingFailed == null)
+			{
+				var composedConvertErrorMessage = string.Format(BindingExpression.ConvertErrorMessage, value, targetType);
+				Debug.WriteLine(composedConvertErrorMessage);
+			}
+			else
+			{
+				BindingFailed?.Invoke(sourceObject, new BindingFailedEventArgs
+				{
+					ConverterFailed = new BindingConverterFailed(value, targetType)
+				});
+			}
+		}
+
+		internal static void OnIndexParsingFailed(string content, TypeInfo sourceType)
+		{
+			if (!IsBindingTracingEnabled)
+				return;
+
+			if (BindingFailed == null)
+			{
+				var composedIndexParsingErrorMessage = string.Format(BindingExpression.IndexParsingFailedErrorMessage, content, sourceType);
+				Debug.WriteLine(composedIndexParsingErrorMessage);
+			}
+			else
+			{
+				BindingFailed?.Invoke(null, new BindingFailedEventArgs
+				{
+					IndexParsingFailed = new BindingIndexParsingFailed(content, sourceType)
+				});
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is getting more complicated than I'm totally comfortable with, but maybe it'll work out okay.

Part of the issue here is that we're trying to unify three related, but distinct, failure modes: 

* Property Not Found
* Converter Failed
* Index Parsing Failed

The way I see it, we have probably three options:

1. Stick to the original, simplest implementation where we just fire off an event with a string message. Easy to consume, easy to use.
2. Unify all the failures into a single event, but include the different failure mode information in the `BindingFailureEventArgs` class. (This is what this PR does)
3. Acknowledge the different failure modes, and split this all apart into three different events. I'm on the fence about this one--the vast majority of users will probably just turn on `IsBindingTracingEnabled` and be happy. But the remaining minority probably want all that extra information. If we take this option, they get it, but at the cost of a more complex implementation, and making it harder to intuitively understand how to use the `DebugSettings` class.
